### PR TITLE
Create Vue 3 photography portfolio scaffold

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.DS_Store
+dist
+.vscode/
+.env.local
+
+# Editor directories and files
+.idea
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Photography Portfolio
+
+Vue 3 + Vite powered photography portfolio with bilingual (中文 / English) support, lazy-loaded gallery grid and detail view designed for Cloudflare Pages deployment.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+## Git LFS
+
+Large image assets in `public/images/` are tracked via [Git Large File Storage](https://git-lfs.com/). Install Git LFS locally and run:
+
+```bash
+git lfs install
+git lfs pull
+```
+
+before building or deploying to ensure all image files are available.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Photography Portfolio</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1443 @@
+{
+  "name": "photography-portfolio",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "photography-portfolio",
+      "version": "0.1.0",
+      "dependencies": {
+        "vue": "^3.4.21",
+        "vue-i18n": "^9.13.1",
+        "vue-router": "^4.3.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.5",
+        "@vitejs/plugin-vue": "^5.0.4",
+        "typescript": "^5.4.5",
+        "vite": "^5.2.0",
+        "vue-tsc": "^2.0.6"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.5.tgz",
+      "integrity": "sha512-5ah5FqZG4pOoHjkvs8mjtv+gPKYU0zCISaYNjBNNqYiaITxW8ZtVih3GS/oTOqN8d9/mDLyrjD46GBApNxmlsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "9.14.5",
+        "@intlify/shared": "9.14.5"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.5.tgz",
+      "integrity": "sha512-IHzgEu61/YIpQV5Pc3aRWScDcnFKWvQA9kigcINcCBXN8mbW+vk9SK+lDxA6STzKQsVJxUPg9ACC52pKKo3SVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "9.14.5",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.5.tgz",
+      "integrity": "sha512-9gB+E53BYuAEMhbCAxVgG38EZrk59sxBtv3jSizNL2hEWlgjBjAw1AwpLHtNaeda12pe6W20OGEa0TwuMSRbyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.3.tgz",
+      "integrity": "sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.3.tgz",
+      "integrity": "sha512-wd+u7SLT/u6knklV/ifG7gr5Qy4GUbH2hMWcDauPFJzmCZUAJ8L2bTkVXC2niOIxp8lk3iH/QX8kSrUxVZrOVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.3.tgz",
+      "integrity": "sha512-lj9ViATR1SsqycwFkJCtYfQTheBdvlWJqzqxwc9f2qrcVrQaF/gCuBRTiTolkRWS6KvNxSk4KHZWG7tDktLgjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.3.tgz",
+      "integrity": "sha512-+Dyo7O1KUmIsbzx1l+4V4tvEVnVQqMOIYtrxK7ncLSknl1xnMHLgn7gddJVrYPNZfEB8CIi3hK8gq8bDhb3h5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.3.tgz",
+      "integrity": "sha512-u9Xg2FavYbD30g3DSfNhxgNrxhi6xVG4Y6i9Ur1C7xUuGDW3banRbXj+qgnIrwRN4KeJ396jchwy9bCIzbyBEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.3.tgz",
+      "integrity": "sha512-5M8kyi/OX96wtD5qJR89a/3x5x8x5inXBZO04JWhkQb2JWavOWfjgkdvUqibGJeNNaz1/Z1PPza5/tAPXICI6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.3.tgz",
+      "integrity": "sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.3.tgz",
+      "integrity": "sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.3.tgz",
+      "integrity": "sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.3.tgz",
+      "integrity": "sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.3.tgz",
+      "integrity": "sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.3.tgz",
+      "integrity": "sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.3.tgz",
+      "integrity": "sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.3.tgz",
+      "integrity": "sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.3.tgz",
+      "integrity": "sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.3.tgz",
+      "integrity": "sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.3.tgz",
+      "integrity": "sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.3.tgz",
+      "integrity": "sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.3.tgz",
+      "integrity": "sha512-+zteHZdoUYLkyYKObGHieibUFLbttX2r+58l27XZauq0tcWYYuKUwY2wjeCN9oK1Um2YgH2ibd6cnX/wFD7DuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.3.tgz",
+      "integrity": "sha512-of1iHkTQSo3kr6dTIRX6t81uj/c/b15HXVsPcEElN5sS859qHrOepM5p9G41Hah+CTqSh2r8Bm56dL2z9UQQ7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.3.tgz",
+      "integrity": "sha512-s0hybmlHb56mWVZQj8ra9048/WZTPLILKxcvcq+8awSZmyiSUZjjem1AhU3Tf4ZKpYhK4mg36HtHDOe8QJS5PQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.3.tgz",
+      "integrity": "sha512-zGIbEVVXVtauFgl3MRwGWEN36P5ZGenHRMgNw88X5wEhEBpq0XrMEZwOn07+ICrwM17XO5xfMZqh0OldCH5VTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.18.tgz",
+      "integrity": "sha512-KeYVbfnbsBCyKG8e3gmUqAfyZNcoj/qpEbHRkQkfZdKOBrU7QQ+BsTdfqLSWX9/m1ytYreMhpKvp+EZi3UFYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
+      "integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.15"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
+      "integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.15.tgz",
+      "integrity": "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.15",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.22.tgz",
+      "integrity": "sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.4",
+        "@vue/shared": "3.5.22",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.22.tgz",
+      "integrity": "sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.22.tgz",
+      "integrity": "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.4",
+        "@vue/compiler-core": "3.5.22",
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.19",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.22.tgz",
+      "integrity": "sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/compiler-vue2": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
+      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/language-core": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
+      "integrity": "sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.15",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^1.0.3",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.22.tgz",
+      "integrity": "sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.22.tgz",
+      "integrity": "sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.22.tgz",
+      "integrity": "sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.22",
+        "@vue/runtime-core": "3.5.22",
+        "@vue/shared": "3.5.22",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.22.tgz",
+      "integrity": "sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22"
+      },
+      "peerDependencies": {
+        "vue": "3.5.22"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.22.tgz",
+      "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==",
+      "license": "MIT"
+    },
+    "node_modules/alien-signals": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
+      "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.3.tgz",
+      "integrity": "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.3",
+        "@rollup/rollup-android-arm64": "4.52.3",
+        "@rollup/rollup-darwin-arm64": "4.52.3",
+        "@rollup/rollup-darwin-x64": "4.52.3",
+        "@rollup/rollup-freebsd-arm64": "4.52.3",
+        "@rollup/rollup-freebsd-x64": "4.52.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.3",
+        "@rollup/rollup-linux-arm64-musl": "4.52.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.3",
+        "@rollup/rollup-linux-x64-gnu": "4.52.3",
+        "@rollup/rollup-linux-x64-musl": "4.52.3",
+        "@rollup/rollup-openharmony-arm64": "4.52.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.3",
+        "@rollup/rollup-win32-x64-gnu": "4.52.3",
+        "@rollup/rollup-win32-x64-msvc": "4.52.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
+      "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-sfc": "3.5.22",
+        "@vue/runtime-dom": "3.5.22",
+        "@vue/server-renderer": "3.5.22",
+        "@vue/shared": "3.5.22"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.5.tgz",
+      "integrity": "sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "9.14.5",
+        "@intlify/shared": "9.14.5",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.12.tgz",
+      "integrity": "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.15",
+        "@vue/language-core": "2.2.12"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "photography-portfolio",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.21",
+    "vue-i18n": "^9.13.1",
+    "vue-router": "^4.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.5",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0",
+    "vue-tsc": "^2.0.6"
+  }
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect x="8" y="14" width="48" height="36" rx="6" ry="6" fill="#1f1f1f"/>
+  <circle cx="32" cy="32" r="14" fill="#ffffff"/>
+  <circle cx="32" cy="32" r="8" fill="#1f1f1f"/>
+  <rect x="20" y="10" width="12" height="8" rx="2" fill="#1f1f1f"/>
+</svg>

--- a/public/images/gallery/work-01.jpg
+++ b/public/images/gallery/work-01.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65de610fb43bc8eaca1ad8301773e91bbd62bc7bfbecc84ca09fa73d339b75d8
+size 100443

--- a/public/images/gallery/work-02.jpg
+++ b/public/images/gallery/work-02.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fbac925f71f176aff42fd6bdee11ca92cc23ddbd1fb152adf84d5ab574018ab
+size 94299

--- a/public/images/gallery/work-03.jpg
+++ b/public/images/gallery/work-03.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1691447e46132dc442175c446587b1102f4ff43fe88a2ba080b7cf5126c06b92
+size 97680

--- a/public/images/gallery/work-04.jpg
+++ b/public/images/gallery/work-04.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70805bb57d0b88b9733bd36471530874743f643178bf808ce0e513457353a74d
+size 84133

--- a/public/images/gallery/work-05.jpg
+++ b/public/images/gallery/work-05.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51c23b856a63c3fbe92ffd57b7f251abac8b8ab7d5d6919d3febf3575a24cc9a
+size 93663

--- a/public/images/gallery/work-06.jpg
+++ b/public/images/gallery/work-06.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7f9d802ff782b41381c9c2f91dd71c293078e419ea042829f56406daa8561be
+size 103647

--- a/public/images/gallery/work-07.jpg
+++ b/public/images/gallery/work-07.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7263aa1fa1e4e1d45c6f5c830ff65c8e8bf5e7dc7ee09ba777d1603e1e6974b
+size 115918

--- a/public/images/gallery/work-08.jpg
+++ b/public/images/gallery/work-08.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b1ce4e8ea776ff1e747dc1e41b97ea3e425e8f42bfa42d8e29f2023c8c7911f
+size 86744

--- a/public/images/previews/work-01.jpg
+++ b/public/images/previews/work-01.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:193b21b15aaa412da9742039eaf762e44d3b5d5cdb513b2b788bec87da9cbbda
+size 931

--- a/public/images/previews/work-02.jpg
+++ b/public/images/previews/work-02.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f92e73ef942c3fbd43b8f666ac74a3aaeedd3f429707273d566c59da9fae6b9
+size 952

--- a/public/images/previews/work-03.jpg
+++ b/public/images/previews/work-03.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:077a5e1931a382f07bffe0e27eb32aa7760e1243d74e8514c8fe8925d1e5d6a8
+size 976

--- a/public/images/previews/work-04.jpg
+++ b/public/images/previews/work-04.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49fcde0defdead57e87a5b76dfe758e1b86cb7d2f3a13022baf52c52079f26b1
+size 923

--- a/public/images/previews/work-05.jpg
+++ b/public/images/previews/work-05.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b6f3d2d961cb5c58de88b7df112df09583c4a725e6b3338866be48972ad09ae
+size 959

--- a/public/images/previews/work-06.jpg
+++ b/public/images/previews/work-06.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:142e68259cf80fac4ed480143e2095f5da5222668abfdb654e52a331febe9edb
+size 920

--- a/public/images/previews/work-07.jpg
+++ b/public/images/previews/work-07.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df6077cc2466d2cea27b4ba046e596de1b683f9577985b31aaf46fa022e92859
+size 1013

--- a/public/images/previews/work-08.jpg
+++ b/public/images/previews/work-08.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e875b08d65ce89f489311ed0543d31c1ecf85403c69ac180f218b5d9f85229fa
+size 908

--- a/public/images/thumbs/work-01.jpg
+++ b/public/images/thumbs/work-01.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c795fe4c6dd4bde4b65849f27a5e797a74bdd89b089ad526446028386d521c9
+size 17476

--- a/public/images/thumbs/work-02.jpg
+++ b/public/images/thumbs/work-02.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27544e6516f156ecdb2ac07efb4cd820e453abe9e44108ab8e19da0a5281ac6d
+size 15821

--- a/public/images/thumbs/work-03.jpg
+++ b/public/images/thumbs/work-03.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:707e6287315857f49c8dfef03c59da58e54078cf219734be6bf63a32ad16df9d
+size 16932

--- a/public/images/thumbs/work-04.jpg
+++ b/public/images/thumbs/work-04.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7af6da037726a4554c218d57fef1953db659c26adbe195d6aa3300ec93e5d7cb
+size 13764

--- a/public/images/thumbs/work-05.jpg
+++ b/public/images/thumbs/work-05.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de5dbee865ef15aac7f80cc43d71b65f7f4b8d59ff06e4054f8e40dd76c07e16
+size 15868

--- a/public/images/thumbs/work-06.jpg
+++ b/public/images/thumbs/work-06.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b073e0f8dee7d61cf74e4829f00584c25b1c1e67f66ee958d72557ead072a8d1
+size 17838

--- a/public/images/thumbs/work-07.jpg
+++ b/public/images/thumbs/work-07.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b06f407e1c3248a7b43a599192a3f528196f6505ee29c96d9d673fb4ade1fd5
+size 21829

--- a/public/images/thumbs/work-08.jpg
+++ b/public/images/thumbs/work-08.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c897bd7b22db3a2f40ec431e92b31037067071bf4a9dbcd09ba57b988f9a062b
+size 13427

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,3 @@
+<template>
+  <RouterView />
+</template>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,0 +1,52 @@
+:root {
+  color: #1f1f1f;
+  background-color: #f7f7f7;
+  font-family: 'Helvetica Neue', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  --max-content-width: 1200px;
+  --gallery-gap: 1.5rem;
+  --muted: #8a8a8a;
+  --surface: #ffffff;
+  --border-color: #e6e6e6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--surface);
+  color: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  background: none;
+  border: none;
+}
+
+#app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 768px) {
+  :root {
+    --gallery-gap: 1rem;
+  }
+}

--- a/src/components/LanguageSwitcher.vue
+++ b/src/components/LanguageSwitcher.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { supportedLocales, type SupportedLocale } from '@/locales';
+
+const route = useRoute();
+const router = useRouter();
+
+const currentLocale = computed(() => route.params.locale as SupportedLocale);
+
+async function switchLocale(locale: SupportedLocale) {
+  if (locale === currentLocale.value) return;
+
+  await router.push({
+    name: (route.name as string) ?? 'gallery',
+    params: {
+      ...route.params,
+      locale
+    },
+    query: route.query
+  });
+}
+</script>
+
+<template>
+  <div class="language-switcher" role="group" aria-label="Language switcher">
+    <button
+      v-for="locale in supportedLocales"
+      :key="locale"
+      type="button"
+      :class="['language-option', { active: locale === currentLocale } ]"
+      @click="switchLocale(locale)"
+    >
+      {{ locale === 'zh' ? '中文' : 'EN' }}
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.language-switcher {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 0.25rem;
+  background-color: var(--surface);
+  gap: 0.25rem;
+}
+
+.language-option {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.language-option.active {
+  background-color: #1f1f1f;
+  color: #fff;
+}
+</style>

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+
+const route = useRoute();
+const { t } = useI18n();
+
+const locale = computed(() => route.params.locale as string);
+
+const links = computed(() => [
+  { key: 'gallery', label: t('navigation.gallery'), name: 'gallery' },
+  { key: 'about', label: t('navigation.about'), name: 'about' },
+  { key: 'contact', label: t('navigation.contact'), name: 'contact' }
+]);
+</script>
+
+<template>
+  <header class="navigation">
+    <div class="brand">
+      <RouterLink :to="{ name: 'gallery', params: { locale } }">
+        {{ t('brand.title') }}
+      </RouterLink>
+    </div>
+    <nav class="nav-links" aria-label="Primary navigation">
+      <RouterLink
+        v-for="link in links"
+        :key="link.key"
+        class="nav-link"
+        :class="{ active: route.name === link.name }"
+        :to="{ name: link.name, params: { ...route.params, locale } }"
+      >
+        {{ link.label }}
+      </RouterLink>
+    </nav>
+    <slot name="right" />
+  </header>
+</template>
+
+<style scoped>
+.navigation {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 2.5rem 0;
+  position: sticky;
+  top: 0;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0));
+  z-index: 10;
+}
+
+.brand {
+  font-size: 1.2rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.nav-link {
+  color: var(--muted);
+  position: relative;
+  padding-bottom: 0.25rem;
+  transition: color 0.2s ease;
+}
+
+.nav-link.active,
+.nav-link:hover {
+  color: #1f1f1f;
+}
+
+.nav-link.active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background-color: #1f1f1f;
+}
+
+@media (max-width: 768px) {
+  .navigation {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 1.5rem 0;
+  }
+
+  .nav-links {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+</style>

--- a/src/components/PhotoCard.vue
+++ b/src/components/PhotoCard.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
+import { useRoute } from 'vue-router';
+import type { Work } from '@/data/gallery';
+
+type Locale = 'zh' | 'en';
+
+const props = defineProps<{ work: Work }>();
+
+const route = useRoute();
+const isVisible = ref(false);
+const isLoaded = ref(false);
+const observer = ref<IntersectionObserver>();
+const container = ref<HTMLElement>();
+const activeSrc = ref(props.work.previewImage);
+
+function loadFullImage() {
+  const image = new Image();
+  image.src = props.work.coverImage;
+  image.onload = () => {
+    activeSrc.value = props.work.coverImage;
+    isLoaded.value = true;
+  };
+}
+
+onMounted(() => {
+  if ('IntersectionObserver' in window) {
+    observer.value = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          isVisible.value = true;
+          observer.value?.disconnect();
+        }
+      });
+    }, { rootMargin: '150px' });
+
+    if (container.value) {
+      observer.value.observe(container.value);
+    }
+  } else {
+    isVisible.value = true;
+  }
+});
+
+onBeforeUnmount(() => {
+  observer.value?.disconnect();
+});
+
+watch(isVisible, (visible) => {
+  if (visible) {
+    loadFullImage();
+  }
+});
+
+const currentLocale = () => (route.params.locale as Locale) ?? 'zh';
+</script>
+
+<template>
+  <div class="photo-card-container" ref="container">
+    <RouterLink
+      :to="{ name: 'work-detail', params: { slug: work.slug, locale: currentLocale() } }"
+      class="photo-card"
+    >
+      <div class="image-wrapper" :class="{ loaded: isLoaded }">
+        <img
+          :src="activeSrc"
+          :alt="work.title[currentLocale()]"
+          loading="lazy"
+          decoding="async"
+        />
+      </div>
+      <div class="photo-meta">
+        <span class="photo-title">{{ work.title[currentLocale()] }}</span>
+        <span class="photo-location">{{ work.location[currentLocale()] }}</span>
+      </div>
+    </RouterLink>
+  </div>
+</template>
+
+<style scoped>
+.photo-card-container {
+  display: block;
+}
+
+.photo-card {
+  display: block;
+  background-color: var(--surface);
+  border-radius: 1.25rem;
+  overflow: hidden;
+  box-shadow: 0 14px 32px rgba(31, 31, 31, 0.08);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.photo-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 40px rgba(31, 31, 31, 0.12);
+}
+
+.image-wrapper {
+  position: relative;
+  padding-bottom: 130%;
+  background: #f0f0f0;
+}
+
+.image-wrapper img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(12px);
+  transform: scale(1.02);
+  transition: filter 0.6s ease, transform 0.6s ease;
+}
+
+.image-wrapper.loaded img {
+  filter: blur(0);
+  transform: scale(1);
+}
+
+.photo-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1.25rem 1.5rem 1.75rem;
+}
+
+.photo-title {
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.photo-location {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+</style>

--- a/src/data/gallery.ts
+++ b/src/data/gallery.ts
@@ -1,0 +1,175 @@
+export type LocaleText = Record<'zh' | 'en', string>;
+
+export interface Work {
+  slug: string;
+  year: number;
+  coverImage: string;
+  previewImage: string;
+  thumbnail: string;
+  title: LocaleText;
+  location: LocaleText;
+  description: LocaleText;
+  shootingDate: string;
+  camera: string;
+  lens: string;
+  aperture: string;
+  shutter: string;
+  iso: string;
+}
+
+export const works: Work[] = [
+  {
+    slug: 'aurora-meadow',
+    year: 2024,
+    coverImage: '/images/gallery/work-01.jpg',
+    previewImage: '/images/previews/work-01.jpg',
+    thumbnail: '/images/thumbs/work-01.jpg',
+    title: { zh: '极光草甸', en: 'Aurora Meadow' },
+    location: { zh: '冰岛东部', en: 'Eastern Iceland' },
+    description: {
+      zh: '晨雾还未散尽，草甸在初升太阳的映照下泛着银蓝色的光，像极光落在大地上。',
+      en: 'Mist lingers over the meadow while the first sunlight paints the grass in silver-blue, as if the aurora had descended.'
+    },
+    shootingDate: '2024-04-15',
+    camera: 'Leica M10-P',
+    lens: 'Summicron-M 35mm f/2',
+    aperture: 'f/5.6',
+    shutter: '1/125s',
+    iso: '200'
+  },
+  {
+    slug: 'crimson-dunes',
+    year: 2023,
+    coverImage: '/images/gallery/work-02.jpg',
+    previewImage: '/images/previews/work-02.jpg',
+    thumbnail: '/images/thumbs/work-02.jpg',
+    title: { zh: '赤色沙丘', en: 'Crimson Dunes' },
+    location: { zh: '纳米布沙漠', en: 'Namib Desert' },
+    description: {
+      zh: '日落前最后一缕光照亮沙丘的脊线，骆驼刺的影子拉出长长的孤独。',
+      en: 'The last flare of sunset traces the dune ridge while camelthorn shadows stretch across the sand.'
+    },
+    shootingDate: '2023-09-02',
+    camera: 'Hasselblad X2D 100C',
+    lens: 'XCD 45mm f/3.5',
+    aperture: 'f/8',
+    shutter: '1/60s',
+    iso: '100'
+  },
+  {
+    slug: 'golden-hour',
+    year: 2022,
+    coverImage: '/images/gallery/work-03.jpg',
+    previewImage: '/images/previews/work-03.jpg',
+    thumbnail: '/images/thumbs/work-03.jpg',
+    title: { zh: '金色时刻', en: 'Golden Hour' },
+    location: { zh: '托斯卡纳丘陵', en: 'Tuscan Hills' },
+    description: {
+      zh: '夕阳绕过橄榄树林，温暖的光线将山谷的纹理刻画得柔和细腻。',
+      en: 'The sun slips past olive groves, carving delicate textures across the warm valley.'
+    },
+    shootingDate: '2022-05-21',
+    camera: 'Fujifilm GFX 100S',
+    lens: 'GF 80mm f/1.7',
+    aperture: 'f/4',
+    shutter: '1/160s',
+    iso: '160'
+  },
+  {
+    slug: 'nocturne',
+    year: 2021,
+    coverImage: '/images/gallery/work-04.jpg',
+    previewImage: '/images/previews/work-04.jpg',
+    thumbnail: '/images/thumbs/work-04.jpg',
+    title: { zh: '夜曲', en: 'Nocturne' },
+    location: { zh: '东京湾', en: 'Tokyo Bay' },
+    description: {
+      zh: '海面被城市灯光染成深蓝，长曝光中的船只仿佛无声的音符。',
+      en: 'City lights tint the bay deep blue while long exposures turn the ferries into silent notes.'
+    },
+    shootingDate: '2021-11-12',
+    camera: 'Sony A7R V',
+    lens: 'FE 24-70mm f/2.8 GM',
+    aperture: 'f/11',
+    shutter: '30s',
+    iso: '64'
+  },
+  {
+    slug: 'verdant-steps',
+    year: 2020,
+    coverImage: '/images/gallery/work-05.jpg',
+    previewImage: '/images/previews/work-05.jpg',
+    thumbnail: '/images/thumbs/work-05.jpg',
+    title: { zh: '翠绿梯田', en: 'Verdant Steps' },
+    location: { zh: '元阳梯田', en: 'Yuanyang Terraces' },
+    description: {
+      zh: '雨后初晴的山谷里，梯田被薄雾缭绕，倒映着天空的青绿。',
+      en: 'Fresh after the rain, terraces embrace the valley with mist and mirror the teal sky.'
+    },
+    shootingDate: '2020-07-08',
+    camera: 'Phase One IQ4',
+    lens: 'Schneider 55mm f/2.8',
+    aperture: 'f/11',
+    shutter: '1/30s',
+    iso: '50'
+  },
+  {
+    slug: 'misty-ridge',
+    year: 2019,
+    coverImage: '/images/gallery/work-06.jpg',
+    previewImage: '/images/previews/work-06.jpg',
+    thumbnail: '/images/thumbs/work-06.jpg',
+    title: { zh: '雾色山脊', en: 'Misty Ridge' },
+    location: { zh: '阿尔卑斯山', en: 'The Alps' },
+    description: {
+      zh: '山脊在云海之间若隐若现，雪线以上的岩石镀上了一层蓝灰色的霜。',
+      en: 'Ridges fade between the clouds while frost paints the rocks in bluish gray above the snow line.'
+    },
+    shootingDate: '2019-02-19',
+    camera: 'Nikon D850',
+    lens: 'AF-S 70-200mm f/2.8E',
+    aperture: 'f/6.3',
+    shutter: '1/250s',
+    iso: '200'
+  },
+  {
+    slug: 'urban-pulse',
+    year: 2018,
+    coverImage: '/images/gallery/work-07.jpg',
+    previewImage: '/images/previews/work-07.jpg',
+    thumbnail: '/images/thumbs/work-07.jpg',
+    title: { zh: '城市脉搏', en: 'Urban Pulse' },
+    location: { zh: '纽约曼哈顿', en: 'Manhattan, New York' },
+    description: {
+      zh: '雨夜的霓虹折射在街道上，斑驳光影像节拍一样律动。',
+      en: 'Neon reflections ripple across the rainy street, pulsing like a metronome.'
+    },
+    shootingDate: '2018-10-03',
+    camera: 'Leica Q2',
+    lens: 'Summilux 28mm f/1.7',
+    aperture: 'f/1.7',
+    shutter: '1/60s',
+    iso: '800'
+  },
+  {
+    slug: 'silent-lake',
+    year: 2017,
+    coverImage: '/images/gallery/work-08.jpg',
+    previewImage: '/images/previews/work-08.jpg',
+    thumbnail: '/images/thumbs/work-08.jpg',
+    title: { zh: '寂静湖面', en: 'Silent Lake' },
+    location: { zh: '加拿大班夫', en: 'Banff, Canada' },
+    description: {
+      zh: '薄雾漂浮在湖面上，唯一的声音来自远处偶尔传来的雁鸣。',
+      en: 'A thin veil of mist drifts over the lake; only distant geese break the silence.'
+    },
+    shootingDate: '2017-06-17',
+    camera: 'Canon EOS 5DS R',
+    lens: 'EF 24-70mm f/2.8L II',
+    aperture: 'f/9',
+    shutter: '1/125s',
+    iso: '100'
+  }
+];
+
+export const years = Array.from(new Set(works.map((work) => work.year))).sort((a, b) => b - a);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,56 @@
+{
+  "brand": {
+    "title": "Portfolio"
+  },
+  "navigation": {
+    "gallery": "Gallery",
+    "about": "About",
+    "contact": "Contact"
+  },
+  "footer": {
+    "copy": "© 2024 Li Mu Photography. All rights reserved."
+  },
+  "gallery": {
+    "years": "Years",
+    "allYears": "All",
+    "title": "Selected Works",
+    "subtitle": "A curated collection of journeys, light and fleeting moments captured around the globe.",
+    "loadMore": "Load more"
+  },
+  "detail": {
+    "back": "Back to gallery",
+    "date": "Captured on",
+    "camera": "Camera",
+    "lens": "Lens",
+    "aperture": "Aperture",
+    "shutter": "Shutter"
+  },
+  "about": {
+    "title": "About the Photographer",
+    "subtitle": "For more than a decade, I have woven light and emotion together to preserve the moments that vanish in a heartbeat.",
+    "storyTitle": "The story so far",
+    "story1": "Since 2010 I have travelled alone from the northern lights to the Sahara, from city nights to alpine star trails. Every press of the shutter is a dialogue with the world.",
+    "story2": "I believe photographs are vessels for memory and feeling. Through light, colour and composition I invite viewers to breathe with the work in the same slice of time.",
+    "highlightTitle": "Recent highlights",
+    "highlight1": "2023 – ‘Voyage’ series awarded IPA Professional Gold",
+    "highlight2": "2022 – Solo exhibition ‘Night & Light’ in London",
+    "highlight3": "Published in National Geographic and Condé Nast Traveler"
+  },
+  "contact": {
+    "title": "Contact & Commissions",
+    "subtitle": "For media interviews, commercial assignments or exhibition inquiries, please get in touch via email or the form below.",
+    "infoTitle": "Stay in touch",
+    "infoDescription": "I split my time between Shanghai and international locations. Meetings are available by appointment.",
+    "emailLabel": "Email",
+    "phoneLabel": "Phone",
+    "locationLabel": "Studio",
+    "locationValue": "Shanghai, China",
+    "form": {
+      "name": "Your name",
+      "email": "Email address",
+      "message": "Message",
+      "submit": "Send"
+    },
+    "toast": "Thank you for your message. I will reply soon!"
+  }
+}

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,0 +1,38 @@
+import { createI18n } from 'vue-i18n';
+
+export const supportedLocales = ['zh', 'en'] as const;
+export type SupportedLocale = (typeof supportedLocales)[number];
+export const defaultLocale: SupportedLocale = 'zh';
+
+const loadedLocales = new Set<string>();
+
+const localeLoaders: Record<SupportedLocale, () => Promise<{ default: Record<string, unknown> }>> = {
+  zh: () => import('./zh.json'),
+  en: () => import('./en.json')
+};
+
+export const i18n = createI18n({
+  legacy: false,
+  locale: defaultLocale,
+  fallbackLocale: defaultLocale,
+  messages: {}
+});
+
+export async function loadLocaleMessages(locale: SupportedLocale) {
+  if (loadedLocales.has(locale)) {
+    return;
+  }
+
+  const loader = localeLoaders[locale];
+  if (!loader) return;
+
+  const messages = await loader();
+  i18n.global.setLocaleMessage(locale, messages.default);
+  loadedLocales.add(locale);
+}
+
+export async function setLocale(locale: SupportedLocale) {
+  await loadLocaleMessages(locale);
+  i18n.global.locale.value = locale;
+  document.documentElement.setAttribute('lang', locale);
+}

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1,0 +1,56 @@
+{
+  "brand": {
+    "title": "作品集"
+  },
+  "navigation": {
+    "gallery": "首页",
+    "about": "关于",
+    "contact": "联系"
+  },
+  "footer": {
+    "copy": "© 2024 摄影师李穆。保留所有权利。"
+  },
+  "gallery": {
+    "years": "拍摄年份",
+    "allYears": "全部",
+    "title": "作品集",
+    "subtitle": "精选影像来自世界各地的旅程、光线与瞬间，呈现摄影师与自然之间的对话。",
+    "loadMore": "加载更多"
+  },
+  "detail": {
+    "back": "返回作品集",
+    "date": "拍摄日期",
+    "camera": "机身",
+    "lens": "镜头",
+    "aperture": "光圈",
+    "shutter": "快门"
+  },
+  "about": {
+    "title": "关于摄影师",
+    "subtitle": "十余年旅途与拍摄经验，将光影与情绪融为一体，记录下那些稍纵即逝的瞬间。",
+    "storyTitle": "旅途中的故事",
+    "story1": "自 2010 年起，我踏上漫长的独行之旅。从北极光到撒哈拉沙漠，从城市夜色到高山星轨，每一次按下快门，都是与世界进行的一场对话。",
+    "story2": "我相信影像不仅是记录，更是情绪与记忆的容器。通过光线、色彩与构图，让观者与作品共同呼吸，沉浸在同一个时空。",
+    "highlightTitle": "近期成就",
+    "highlight1": "2023 年《行旅》系列获 IPA 国际摄影奖专业组金奖",
+    "highlight2": "2022 年在伦敦举办个展《夜与光》",
+    "highlight3": "作品发表于《国家地理》《旅行家》等刊物"
+  },
+  "contact": {
+    "title": "联系与合作",
+    "subtitle": "欢迎媒体采访、商业合作与艺术展览邀约。请通过邮件或表单与我取得联系。",
+    "infoTitle": "联系信息",
+    "infoDescription": "我常年往返于上海与各地拍摄，如需面对面会谈，可提前预约。",
+    "emailLabel": "邮箱",
+    "phoneLabel": "电话",
+    "locationLabel": "工作室",
+    "locationValue": "中国 · 上海",
+    "form": {
+      "name": "姓名",
+      "email": "邮箱",
+      "message": "留言内容",
+      "submit": "发送"
+    },
+    "toast": "感谢留言，我会尽快回复。"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,18 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import router from './router';
+import './assets/main.css';
+import { i18n, defaultLocale, setLocale } from './locales';
+
+async function bootstrap() {
+  await setLocale(defaultLocale);
+
+  const app = createApp(App);
+  app.use(router);
+  app.use(i18n);
+
+  await router.isReady();
+  app.mount('#app');
+}
+
+bootstrap();

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,56 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import LocaleLayout from '@/views/LocaleLayout.vue';
+import GalleryView from '@/views/GalleryView.vue';
+import WorkDetailView from '@/views/WorkDetailView.vue';
+import AboutView from '@/views/AboutView.vue';
+import ContactView from '@/views/ContactView.vue';
+import { defaultLocale, supportedLocales, setLocale, type SupportedLocale } from '@/locales';
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    {
+      path: '/:locale(zh|en)',
+      component: LocaleLayout,
+      children: [
+        {
+          path: '',
+          name: 'gallery',
+          component: GalleryView
+        },
+        {
+          path: 'works/:slug',
+          name: 'work-detail',
+          component: WorkDetailView,
+          props: true
+        },
+        {
+          path: 'about',
+          name: 'about',
+          component: AboutView
+        },
+        {
+          path: 'contact',
+          name: 'contact',
+          component: ContactView
+        }
+      ]
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      redirect: `/${defaultLocale}`
+    }
+  ]
+});
+
+router.beforeEach(async (to) => {
+  const locale = to.params.locale as SupportedLocale | undefined;
+
+  if (!locale || !supportedLocales.includes(locale)) {
+    return `/${defaultLocale}`;
+  }
+
+  await setLocale(locale);
+});
+
+export default router;

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <section class="page about">
+    <header class="page-header">
+      <h1>{{ t('about.title') }}</h1>
+      <p>{{ t('about.subtitle') }}</p>
+    </header>
+    <div class="about-grid">
+      <article class="bio">
+        <h2>{{ t('about.storyTitle') }}</h2>
+        <p>{{ t('about.story1') }}</p>
+        <p>{{ t('about.story2') }}</p>
+      </article>
+      <aside class="highlights">
+        <h2>{{ t('about.highlightTitle') }}</h2>
+        <ul>
+          <li>{{ t('about.highlight1') }}</li>
+          <li>{{ t('about.highlight2') }}</li>
+          <li>{{ t('about.highlight3') }}</li>
+        </ul>
+      </aside>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  letter-spacing: 0.16em;
+}
+
+.page-header p {
+  max-width: 38rem;
+  color: var(--muted);
+}
+
+.about-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 3rem;
+}
+
+.bio,
+.highlights {
+  background-color: #f9f9f9;
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  box-shadow: 0 12px 30px rgba(31, 31, 31, 0.08);
+}
+
+.bio p {
+  line-height: 1.9;
+}
+
+.highlights ul {
+  margin: 1.5rem 0 0;
+  padding-left: 1.25rem;
+  color: #424242;
+  line-height: 1.8;
+}
+
+@media (max-width: 1024px) {
+  .about-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/views/ContactView.vue
+++ b/src/views/ContactView.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { reactive } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+
+const form = reactive({
+  name: '',
+  email: '',
+  message: ''
+});
+
+function submit() {
+  alert(t('contact.toast'));
+  form.name = '';
+  form.email = '';
+  form.message = '';
+}
+</script>
+
+<template>
+  <section class="page contact">
+    <header class="page-header">
+      <h1>{{ t('contact.title') }}</h1>
+      <p>{{ t('contact.subtitle') }}</p>
+    </header>
+    <div class="contact-grid">
+      <article class="contact-info">
+        <h2>{{ t('contact.infoTitle') }}</h2>
+        <p>{{ t('contact.infoDescription') }}</p>
+        <ul>
+          <li><strong>{{ t('contact.emailLabel') }}:</strong> hello@example.com</li>
+          <li><strong>{{ t('contact.phoneLabel') }}:</strong> +86 138 0000 0000</li>
+          <li><strong>{{ t('contact.locationLabel') }}:</strong> {{ t('contact.locationValue') }}</li>
+        </ul>
+      </article>
+      <form class="contact-form" @submit.prevent="submit">
+        <label>
+          {{ t('contact.form.name') }}
+          <input v-model="form.name" type="text" required />
+        </label>
+        <label>
+          {{ t('contact.form.email') }}
+          <input v-model="form.email" type="email" required />
+        </label>
+        <label>
+          {{ t('contact.form.message') }}
+          <textarea v-model="form.message" rows="5" required></textarea>
+        </label>
+        <button type="submit">{{ t('contact.form.submit') }}</button>
+      </form>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  letter-spacing: 0.16em;
+}
+
+.page-header p {
+  max-width: 36rem;
+  color: var(--muted);
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 3rem;
+}
+
+.contact-info,
+.contact-form {
+  background-color: #f9f9f9;
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  box-shadow: 0 12px 30px rgba(31, 31, 31, 0.08);
+}
+
+.contact-info ul {
+  margin: 1.5rem 0 0;
+  padding-left: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.contact-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+input,
+textarea {
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border-color);
+  font: inherit;
+  background-color: #fff;
+}
+
+button[type='submit'] {
+  align-self: flex-start;
+  padding: 0.85rem 2.5rem;
+  border-radius: 999px;
+  border: none;
+  background-color: #1f1f1f;
+  color: #fff;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 1024px) {
+  .contact-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/views/GalleryView.vue
+++ b/src/views/GalleryView.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import PhotoCard from '@/components/PhotoCard.vue';
+import { works, years } from '@/data/gallery';
+
+const { t } = useI18n();
+const activeYear = ref<'all' | number>('all');
+const visibleCount = ref(6);
+
+const sortedWorks = computed(() =>
+  [...works].sort((a, b) => {
+    if (a.year === b.year) {
+      return a.slug.localeCompare(b.slug);
+    }
+    return b.year - a.year;
+  })
+);
+
+const filteredWorks = computed(() => {
+  const list = activeYear.value === 'all'
+    ? sortedWorks.value
+    : sortedWorks.value.filter((work) => work.year === activeYear.value);
+
+  return list.slice(0, visibleCount.value);
+});
+
+const totalMatching = computed(() =>
+  activeYear.value === 'all'
+    ? sortedWorks.value.length
+    : sortedWorks.value.filter((work) => work.year === activeYear.value).length
+);
+
+const hasMore = computed(() => filteredWorks.value.length < totalMatching.value);
+
+watch(activeYear, () => {
+  visibleCount.value = 6;
+});
+
+function showMore() {
+  visibleCount.value += 4;
+}
+</script>
+
+<template>
+  <section class="gallery">
+    <aside class="years">
+      <span class="years-label">{{ t('gallery.years') }}</span>
+      <button
+        class="year"
+        :class="{ active: activeYear === 'all' }"
+        type="button"
+        @click="activeYear = 'all'"
+      >
+        {{ t('gallery.allYears') }}
+      </button>
+      <button
+        v-for="year in years"
+        :key="year"
+        class="year"
+        :class="{ active: activeYear === year }"
+        type="button"
+        @click="activeYear = year"
+      >
+        {{ year }}
+      </button>
+    </aside>
+    <div class="grid">
+      <header class="gallery-header">
+        <h1>{{ t('gallery.title') }}</h1>
+        <p>{{ t('gallery.subtitle') }}</p>
+      </header>
+      <div class="photo-grid">
+        <PhotoCard v-for="work in filteredWorks" :key="work.slug" :work="work" />
+      </div>
+      <div v-if="hasMore" class="more">
+        <button type="button" @click="showMore">{{ t('gallery.loadMore') }}</button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.gallery {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 3rem;
+  min-height: 70vh;
+}
+
+.years {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+  position: sticky;
+  top: 120px;
+  align-self: start;
+}
+
+.years-label {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: #b0b0b0;
+}
+
+.year {
+  text-align: left;
+  color: inherit;
+  padding: 0.25rem 0;
+  position: relative;
+  transition: color 0.2s ease;
+}
+
+.year.active,
+.year:hover {
+  color: #1f1f1f;
+}
+
+.year.active::before {
+  content: '';
+  position: absolute;
+  left: -0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 1.5rem;
+  border-radius: 999px;
+  background-color: #1f1f1f;
+}
+
+.grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.gallery-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.gallery-header h1 {
+  font-size: 2rem;
+  letter-spacing: 0.18em;
+  margin: 0;
+}
+
+.gallery-header p {
+  margin: 0;
+  max-width: 32rem;
+  color: var(--muted);
+}
+
+.photo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: var(--gallery-gap);
+}
+
+.more {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.more button {
+  padding: 0.75rem 2.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background-color: var(--surface);
+  transition: background-color 0.2s ease;
+}
+
+.more button:hover {
+  background-color: #1f1f1f;
+  color: #fff;
+}
+
+@media (max-width: 1024px) {
+  .gallery {
+    grid-template-columns: 1fr;
+  }
+
+  .years {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.5rem;
+    justify-content: flex-start;
+  }
+
+  .year::before {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .gallery-header h1 {
+    font-size: 1.6rem;
+  }
+
+  .photo-grid {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
+}
+</style>

--- a/src/views/LocaleLayout.vue
+++ b/src/views/LocaleLayout.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import NavigationBar from '@/components/NavigationBar.vue';
+import LanguageSwitcher from '@/components/LanguageSwitcher.vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <div class="layout">
+    <NavigationBar>
+      <template #right>
+        <LanguageSwitcher />
+      </template>
+    </NavigationBar>
+    <main class="content">
+      <RouterView />
+    </main>
+    <footer class="footer">
+      <p>{{ t('footer.copy') }}</p>
+    </footer>
+  </div>
+</template>
+
+<style scoped>
+.layout {
+  width: min(100%, var(--max-content-width));
+  margin: 0 auto;
+  padding: 0 2.5rem 3rem;
+}
+
+.content {
+  flex: 1;
+}
+
+.footer {
+  padding-top: 4rem;
+  padding-bottom: 2rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .layout {
+    padding: 0 1.25rem 2.5rem;
+  }
+}
+</style>

--- a/src/views/WorkDetailView.vue
+++ b/src/views/WorkDetailView.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { works, type Work } from '@/data/gallery';
+
+type Locale = 'zh' | 'en';
+
+const route = useRoute();
+const router = useRouter();
+const { t } = useI18n();
+
+const locale = computed<Locale>(() => (route.params.locale as Locale) ?? 'zh');
+const work = computed<Work | undefined>(() => works.find((item: Work) => item.slug === route.params.slug));
+
+if (!work.value) {
+  router.replace({ name: 'gallery', params: { locale: locale.value } });
+}
+
+function goBack() {
+  router.push({ name: 'gallery', params: { locale: locale.value } });
+}
+</script>
+
+<template>
+  <section v-if="work" class="detail">
+    <button class="back" type="button" @click="goBack">
+      ← {{ t('detail.back') }}
+    </button>
+    <div class="detail-layout">
+      <div class="detail-image">
+        <img :src="work.coverImage" :alt="work.title[locale]" loading="lazy" decoding="async" />
+      </div>
+      <div class="detail-info">
+        <header>
+          <p class="work-year">{{ work.year }}</p>
+          <h1>{{ work.title[locale] }}</h1>
+          <p class="work-location">{{ work.location[locale] }}</p>
+        </header>
+        <div class="meta-grid">
+          <div class="meta-item">
+            <span class="label">{{ t('detail.date') }}</span>
+            <span>{{ work.shootingDate }}</span>
+          </div>
+          <div class="meta-item">
+            <span class="label">{{ t('detail.camera') }}</span>
+            <span>{{ work.camera }}</span>
+          </div>
+          <div class="meta-item">
+            <span class="label">{{ t('detail.lens') }}</span>
+            <span>{{ work.lens }}</span>
+          </div>
+          <div class="meta-item">
+            <span class="label">{{ t('detail.aperture') }}</span>
+            <span>{{ work.aperture }}</span>
+          </div>
+          <div class="meta-item">
+            <span class="label">{{ t('detail.shutter') }}</span>
+            <span>{{ work.shutter }}</span>
+          </div>
+          <div class="meta-item">
+            <span class="label">ISO</span>
+            <span>{{ work.iso }}</span>
+          </div>
+        </div>
+        <div class="description">
+          <p>{{ work.description[locale] }}</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.back {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-bottom: 1.5rem;
+}
+
+.detail-layout {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 3rem;
+  align-items: start;
+}
+
+.detail-image {
+  background: var(--surface);
+  border-radius: 1.5rem;
+  overflow: hidden;
+  box-shadow: 0 18px 40px rgba(31, 31, 31, 0.1);
+}
+
+.detail-image img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.detail-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.detail-info h1 {
+  font-size: 2rem;
+  letter-spacing: 0.2em;
+  margin: 0.5rem 0 0;
+}
+
+.work-year {
+  font-size: 0.85rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.work-location {
+  margin: 0;
+  color: var(--muted);
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem 2rem;
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.label {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #b0b0b0;
+}
+
+.description {
+  font-size: 0.95rem;
+  line-height: 1.8;
+  color: #424242;
+}
+
+@media (max-width: 1024px) {
+  .detail-layout {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true,
+    "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- initialize a Vite + Vue 3 + TypeScript project with routing, i18n, and base styling
- build gallery, detail, about, and contact views with bilingual content and progressive image handling
- configure Git LFS for image assets and document local setup instructions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc619e748c832c824e0210c4fb5b4c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Launched a Vue 3 photography portfolio with bilingual (中文/EN) support.
  - Gallery with year filters, incremental “Load More,” lazy-loaded images, and detail pages.
  - Responsive Navigation Bar, Language Switcher, and views for Gallery, About, and Contact.
- Documentation
  - Added README with setup, build steps, and Git LFS guidance for images.
- Chores
  - Configured Git LFS for image assets and expanded .gitignore.
  - Added project configuration for Vite, TypeScript, routing, and i18n.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->